### PR TITLE
feature/temporaryUser 仮ユーザー作成機能 #18

### DIFF
--- a/app/controllers/v1/areas_controller.rb
+++ b/app/controllers/v1/areas_controller.rb
@@ -1,0 +1,8 @@
+module V1
+  class AreasController < ApplicationController
+    def index
+      areas = Area.all.order_asc
+      render_collection_serializer(areas, AreaSerializer)
+    end
+  end
+end

--- a/app/controllers/v1/top_controller.rb
+++ b/app/controllers/v1/top_controller.rb
@@ -1,0 +1,7 @@
+module V1
+  class TopController < ApplicationController
+    def index
+      render json: { 'welcome!': 'APIサーバー元気に稼働中' }
+    end
+  end
+end

--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -1,12 +1,8 @@
 module V1
   class UsersController < ApplicationController
-    before_action :authorize!, except: %i[top create login]
+    before_action :authorize!, except: %i[create login]
     before_action :set_user, only: %i[update destroy show]
     before_action :current_user?, only: %i[update destroy]
-
-    def top
-      render json: { 'welcome!': 'APIサーバー元気に稼働中' }
-    end
 
     def create
       user = User.create!(sign_up_user_params)

--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -1,12 +1,17 @@
 module V1
   class UsersController < ApplicationController
-    before_action :authorize!, except: %i[create login]
+    before_action :authorize!, except: %i[create_temp_user login]
     before_action :set_user, only: %i[update destroy show]
     before_action :current_user?, only: %i[update destroy]
 
-    def create
-      user = User.create!(sign_up_user_params)
-      render_serializer(user, MeSerializer)
+    def create_temp_user
+      temp_user = User.create!(sign_up_temp_user_params)
+      render_serializer(temp_user, MeSerializer)
+    end
+
+    def update_from_temp_to_formal
+      @current_user.update!(sign_up_formal_user_params)
+      render_serializer(@current_user, MeSerializer)
     end
 
     def login
@@ -42,10 +47,13 @@ module V1
         error_message(:unauthorized, '権限がありません') unless @user.id == @current_user.id
       end
 
-      def sign_up_user_params
-        params.require(:user).permit(
-          :name, :email, :password, :password_confirmation,
-          :birth_year, :gender, :area_id
+      def sign_up_temp_user_params
+        params.require(:temp_user).permit(:birth_year, :area_id)
+      end
+
+      def sign_up_formal_user_params
+        params.require(:formal_user).permit(
+          :email, :password, :password_confirmation
         )
       end
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,4 +2,5 @@ class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
   scope :recent, -> { order(updated_at: :desc) }
+  scope :order_asc, -> { order(order: :asc) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,18 @@
 class User < ApplicationRecord
-  has_secure_password validations: false
   has_secure_token
+  # PasswordのVaridatesをupdate時のみにする
+  has_secure_password validations: false
+  validate(on: :update) do |record|
+    record.errors.add(:password, :blank) if record.password_digest.blank?
+  end
+  validates :password, on: :update, length: { maximum: ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED }
+  validates :password, on: :update, confirmation: { allow_blank: true }
+
   validates :name, length: { maximum: 20 }
   before_save { self.email = email&.downcase }
-  validates :email, uniqueness: { case_sensitive: false }, length: { maximum: 255 }
+  validates :email, uniqueness: { case_sensitive: false },
+                    length: { maximum: 255 }
+  validates :email, on: :update, presence: true
   validates :birth_year, numericality: true
 
   belongs_to :area

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,12 +1,10 @@
 class User < ApplicationRecord
-  has_secure_password
+  has_secure_password validations: false
   has_secure_token
   validates :name, length: { maximum: 20 }
-  before_save { self.email = email.downcase }
-  validates :email, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 255 }
-  validates :password_digest, presence: true
+  before_save { self.email = email&.downcase }
+  validates :email, uniqueness: { case_sensitive: false }, length: { maximum: 255 }
   validates :birth_year, numericality: true
-  validates :gender, numericality: true
 
   belongs_to :area
   has_many :my_plans

--- a/app/serializers/area_serializer.rb
+++ b/app/serializers/area_serializer.rb
@@ -1,0 +1,5 @@
+class AreaSerializer < ActiveModel::Serializer
+  attributes  :id,
+              :name,
+              :order
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root to: 'v1/users#top', format: 'json'
+  root 'v1/top#index'
   namespace :v1, format: 'json' do
     # Users
     resources :users, only: %i[show update destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
     resources :users, only: %i[show update destroy]
     post 'sign_up', to: 'users#create'
     post 'login', to: 'users#login'
+    # Areas
+    resources :areas, only: %i[index]
     # Plans
     resources :plans, only: %i[show]
     # Spots

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,8 @@ Rails.application.routes.draw do
   namespace :v1, format: 'json' do
     # Users
     resources :users, only: %i[show update destroy]
-    post 'sign_up', to: 'users#create'
+    post 'temp_sign_up', to: 'users#create_temp_user'
+    post 'formal_sign_up', to: 'users#update_from_temp_to_formal'
     post 'login', to: 'users#login'
     # Areas
     resources :areas, only: %i[index]

--- a/db/fixtures/development/01_master_data.rb
+++ b/db/fixtures/development/01_master_data.rb
@@ -12,9 +12,10 @@
 end
 
 # Areasマスタ エリア設定きまるまで
-(0...47).each do |i|
+(1..47).each do |i|
   Area.seed do |s|
-    s.id = i + 1
-    s.name = "東京#{i + 1}"
+    s.id = i
+    s.name = "東京#{i}"
+    s.order = i
   end
 end

--- a/db/migrate/20200221052716_change_not_null_to_users.rb
+++ b/db/migrate/20200221052716_change_not_null_to_users.rb
@@ -1,0 +1,13 @@
+class ChangeNotNullToUsers < ActiveRecord::Migration[5.2]
+  def up
+    change_column_null :users, :email, true
+    change_column_null :users, :password_digest, true
+    change_column_null :users, :gender, true
+  end
+
+  def down
+    change_column_null :users, :email, false
+    change_column_null :users, :password_digest, false
+    change_column_null :users, :gender, false
+  end
+end

--- a/db/migrate/20200223061122_add_order_to_areas.rb
+++ b/db/migrate/20200223061122_add_order_to_areas.rb
@@ -1,0 +1,8 @@
+class AddOrderToAreas < ActiveRecord::Migration[5.2]
+  def change
+    change_table :areas do |t|
+      t.integer :order, null: false
+      t.index :order, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,12 +77,12 @@ ActiveRecord::Schema.define(version: 2020_02_23_061122) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "email", null: false
-    t.string "password_digest", null: false
+    t.string "email"
+    t.string "password_digest"
     t.string "token", null: false
     t.string "name"
     t.integer "birth_year", null: false
-    t.integer "gender", null: false
+    t.integer "gender"
     t.bigint "area_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_14_055407) do
+ActiveRecord::Schema.define(version: 2020_02_23_061122) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,8 @@ ActiveRecord::Schema.define(version: 2020_02_14_055407) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "order", null: false
+    t.index ["order"], name: "index_areas_on_order", unique: true
   end
 
   create_table "my_plans", force: :cascade do |t|

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,5 +13,6 @@ FactoryBot.define do
 
   factory :area, class: Area do
     name { "東京" }
+    sequence(:order) { |n| n }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,6 +11,19 @@ FactoryBot.define do
     end
   end
 
+  factory :temp_user, class: User do
+    birth_year { 1999 }
+    trait :with_area do
+      area
+    end
+  end
+
+  factory :formal_user, class: User do
+    sequence(:email) { |n| "factory-#{n}@example.com" }
+    password { 'password' }
+    password_confirmation { 'password' }
+  end
+
   factory :area, class: Area do
     name { "東京" }
     sequence(:order) { |n| n }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,64 +1,67 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  let(:user) { build(:user, :with_area) }
-  describe 'Validates' do
-    it 'shold be valid' do
-      expect(user).to be_valid
-    end
-    describe 'name' do
-      it 'should be proper long' do
-        user.name = 'a' * 20
+  describe 'create' do
+    let(:user) { build(:user, :with_area) }
+    describe 'Validates' do
+      it 'shold be valid' do
         expect(user).to be_valid
       end
-      it 'should not be too long' do
-        user.name = 'a' * 21
-        expect(user).not_to be_valid
+      describe 'name' do
+        it 'should be proper long' do
+          user.name = 'a' * 20
+          expect(user).to be_valid
+        end
+        it 'should not be too long' do
+          user.name = 'a' * 21
+          expect(user).not_to be_valid
+        end
+      end
+      describe 'email' do
+        it 'should be proper long' do
+          user.email = 'a' * 243 + '@example.com'
+          expect(user).to be_valid
+        end
+        it 'should not be too long' do
+          user.email = 'a' * 244 + '@example.com'
+          expect(user).not_to be_valid
+        end
+        it 'addresses should be unique' do
+          duplicate_user = build(:user, email: user.email)
+          user.save
+          expect(duplicate_user).not_to be_valid
+        end
       end
     end
-    describe 'email' do
-      # it 'should be present' do
-      #   user.email = ''
-      #   expect(user).not_to be_valid
-      # end
-      it 'should be proper long' do
-        user.email = 'a' * 243 + '@example.com'
-        expect(user).to be_valid
+  end
+  describe 'update' do
+    let(:temp_user) { create(:temp_user, :with_area) }
+    let(:params) { attributes_for(:formal_user) }
+    describe 'Validates' do
+      it 'shold be valid' do
+        temp_user.update!(params)
+        expect(temp_user.errors).to be_empty
       end
-      it 'should not be too long' do
-        user.email = 'a' * 244 + '@example.com'
-        expect(user).not_to be_valid
+      describe 'email' do
+        it 'should be present' do
+          params[:email] = ''
+          expect{ temp_user.update!(params) }.to raise_error ActiveRecord::RecordInvalid
+        end
       end
-      it 'addresses should be unique' do
-        duplicate_user = build(:user, email: user.email)
-        user.save
-        expect(duplicate_user).not_to be_valid
+      describe 'password' do
+        it 'should be present' do
+          params[:password] = ''
+          expect{ temp_user.update!(params) }.to raise_error ActiveRecord::RecordInvalid
+        end
+        it 'confirmation should be present' do
+          params[:password_confirmation] = ''
+          expect{ temp_user.update!(params) }.to raise_error ActiveRecord::RecordInvalid
+        end
+        it 'not should be invalid' do
+          params[:password_confirmation] = 'pass'
+          expect{ temp_user.update!(params) }.to raise_error ActiveRecord::RecordInvalid
+        end
       end
-      # it 'addresses should be alphabetically unique' do
-      #   user = create(:user, email: 'JO@examPle.COM')
-      #   duplicate_user = build(:user, email: user.email.downcase)
-      #   expect(duplicate_user).not_to be_valid
-      # end
-      # it 'saves only downcase email' do
-      #   user = create(:user, email: 'JO@examPle.COM')
-      #   expect(user.reload.email).to eq 'jo@example.com'
-      # end
-    end
-    describe 'password' do
-      # it 'should be present' do
-      #   user.password = ''
-      #   user.password_confirmation = ''
-      #   expect(user).not_to be_valid
-      # end
-      # it 'confirmation should be present' do
-      #   user.password_confirmation = ''
-      #   expect(user).not_to be_valid
-      # end
-      # it 'not should be invalid' do
-      #   user.password = 'password'
-      #   user.password_confirmation = 'pass'
-      #   expect(user).not_to be_valid
-      # end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe User, type: :model do
       end
     end
     describe 'email' do
-      it 'should be present' do
-        user.email = ''
-        expect(user).not_to be_valid
-      end
+      # it 'should be present' do
+      #   user.email = ''
+      #   expect(user).not_to be_valid
+      # end
       it 'should be proper long' do
         user.email = 'a' * 243 + '@example.com'
         expect(user).to be_valid
@@ -45,20 +45,20 @@ RSpec.describe User, type: :model do
       # end
     end
     describe 'password' do
-      it 'should be present' do
-        user.password = ''
-        user.password_confirmation = ''
-        expect(user).not_to be_valid
-      end
-      it 'confirmation should be present' do
-        user.password_confirmation = ''
-        expect(user).not_to be_valid
-      end
-      it 'not should be invalid' do
-        user.password = 'password'
-        user.password_confirmation = 'pass'
-        expect(user).not_to be_valid
-      end
+      # it 'should be present' do
+      #   user.password = ''
+      #   user.password_confirmation = ''
+      #   expect(user).not_to be_valid
+      # end
+      # it 'confirmation should be present' do
+      #   user.password_confirmation = ''
+      #   expect(user).not_to be_valid
+      # end
+      # it 'not should be invalid' do
+      #   user.password = 'password'
+      #   user.password_confirmation = 'pass'
+      #   expect(user).not_to be_valid
+      # end
     end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -12,10 +12,9 @@ RSpec.describe 'Users', type: :request do
         area = create(:area)
         @area_id = area.id
       end
-      describe '/sign_up POST' do
-        let(:params) { attributes_for(:user, area_id: @area_id) }
-        subject { post '/v1/sign_up', params: { "user": params } }
-        let(:res_keys) { %w[name email] }
+      describe '/temp_sign_up POST' do
+        subject { post '/v1/temp_sign_up', params: { "temp_user": params } }
+        let(:params) { attributes_for(:temp_user, area_id: @area_id) }
         let(:res_body) do
           subject
           JSON.parse(response.body)
@@ -23,10 +22,17 @@ RSpec.describe 'Users', type: :request do
         it { is_expected.to eq 200 }
         it { expect { subject }.to change(User, :count).by(+1) }
       end
+      describe '/formal_sign_up POST' do
+        subject { post '/v1/formal_sign_up', headers: options , params: { "formal_user": params } }
+        let(:temp_user) { create(:temp_user, :with_area) }
+        let(:params) { attributes_for(:formal_user) }
+        let(:options) { { HTTP_AUTHORIZATION: "Bearer #{temp_user.token}" } }
+        it { is_expected.to eq 200 }
+      end
       describe '/login POST' do
-        let(:sign_up_params) { attributes_for(:user, area_id: @area_id) }
-        let!(:user) { User.create(sign_up_params) }
         subject { post '/v1/login', params: @params }
+        let!(:user) { User.create(sign_up_params) }
+        let(:sign_up_params) { attributes_for(:user, area_id: @area_id) }
         let(:res_body) do
           subject
           JSON.parse(response.body)


### PR DESCRIPTION
### やりたいこと
* ログインしてなくても提案機能を使いたい
* マイプラン等のユーザーと紐付けする機能をノンログインでも使いたい

### やったこと
* usersのNNを解除(仮情報だけでも登録できるように)
* 今までのcreate削除
* 仮登録 機能作成
* 本登録 機能作成(仮Tokenを持ってupdateする形)
* usersのvalidatesを仮、本登録時に効くように変更
* RSpecのusers model test を仮、本登録時に効くように変更

* rootを表示する部分をtop controller に移行した