### PR TITLE
Feature/status code エラーハンドリング、ステータスコードの整理

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,16 @@
 class ApplicationController < ActionController::API
   include ActionController::HttpAuthentication::Token::ControllerMethods
+  rescue_from StandardError, with: :render_500
+  rescue_from AbstractController::ActionNotFound, with: :render_404
+  rescue_from ActionView::MissingTemplate, with: :render_404
+  rescue_from ActionController::RoutingError, with: :render_404
+  rescue_from ActionController::UnknownFormat, with: :render_404
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+  rescue_from ActiveRecord::RecordNotSaved, with: :render_404
+  rescue_from ActiveRecord::RecordInvalid, with: :render_400
+  rescue_from ActionController::ParameterMissing, with: :render_400
+  rescue_from ActionController::InvalidCrossOriginRequest, with: :render_400
+  rescue_from ActionController::InvalidAuthenticityToken, with: :render_422
 
   def authorize!
     return if current_user
@@ -11,8 +22,8 @@ class ApplicationController < ActionController::API
     @current_user ||= User.find_by(token: bearer_token)
   end
 
-  def render_serializer(data, set_serializer)
-    render json: data, serializer: set_serializer
+  def render_serializer(data, set_serializer, status = :ok)
+    render json: data, serializer: set_serializer, status: status
   end
 
   def render_collection_serializer(datas, set_serializer)
@@ -23,6 +34,49 @@ class ApplicationController < ActionController::API
 
   def error_message(status, message)
     render json: { 'message': message }, status: status
+  end
+
+  def render_400(error)
+    Rails.logger.info(error)
+    render json: {
+      message: 'Bad Request',
+      errors: error.message
+    }, status: :bad_request
+  end
+
+  def render_403
+    render json: {
+      message: 'Forbidden'
+    }, status: :forbidden
+  end
+
+  def render_404(error)
+    Rails.logger.info(error)
+    render json: {
+      message: 'Not Found',
+      errors: error.message
+    }, status: :not_found
+  end
+
+  def render_422(error)
+    Rails.logger.info(error)
+    render json: {
+      message: 'Unprocessable Entity',
+      errors: error.message
+    }, status: :unprocessable_entity
+  end
+
+  def render_500(error)
+    Rails.logger.error(error)
+    ExceptionNotifier.notify_exception(
+      error,
+      env: request.env,
+      data: { message: error.message }
+    )
+    render json: {
+      message: 'Internal Server Error',
+      errors: error.message
+    }, status: :internal_server_error
   end
 
   private

--- a/app/controllers/v1/mypage/my_plans_controller.rb
+++ b/app/controllers/v1/mypage/my_plans_controller.rb
@@ -20,7 +20,7 @@ module V1
 
       def destroy
         @my_plan.destroy!
-        render json: { 'message': 'デート予定を取り消しました' }
+        render status: :no_content
       end
 
       private

--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -34,7 +34,7 @@ module V1
 
     def destroy
       @user.destroy!
-      render json: { 'message': '正常にUser削除されました' }
+      render status: :no_content
     end
 
     private
@@ -44,7 +44,7 @@ module V1
       end
 
       def current_user?
-        error_message(:unauthorized, '権限がありません') unless @user.id == @current_user.id
+        error_message(:forbidden, '権限がありません') unless @user.id == @current_user.id
       end
 
       def sign_up_temp_user_params

--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -19,7 +19,11 @@ module V1
       if user&.authenticate(login_params[:password])
         render_serializer(user, MeSerializer)
       else
-        error_message(:unauthorized, 'ログインに失敗しました')
+        render_error_message(
+          'Unauthorized',
+          'ログインに失敗しました',
+          :unauthorized
+        )
       end
     end
 
@@ -44,7 +48,7 @@ module V1
       end
 
       def current_user?
-        error_message(:forbidden, '権限がありません') unless @user.id == @current_user.id
+        render_403 unless @user.id == @current_user.id
       end
 
       def sign_up_temp_user_params

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,7 @@ module DateSuggesterRails
     config.load_defaults 5.2
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
+    config.i18n.default_locale = :ja
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,207 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+      - 日
+      - 月
+      - 火
+      - 水
+      - 木
+      - 金
+      - 土
+    abbr_month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    day_names:
+      - 日曜日
+      - 月曜日
+      - 火曜日
+      - 水曜日
+      - 木曜日
+      - 金曜日
+      - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    order:
+      - :year
+      - :month
+      - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: "バリデーションに失敗しました: %{errors}"
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ""
+      format:
+        delimiter: ""
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ""
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ""
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/spec/application_helper.rb
+++ b/spec/application_helper.rb
@@ -6,7 +6,7 @@ shared_examples_for 'Tokenがおかしい時' do |exist: false, different: false
     end
   end
   if different
-    it '異なる 401 Unauthorized' do
+    it '異なる 403 Forbidden' do
       set_different_token
       expect(subject).to eq 403
     end
@@ -14,13 +14,13 @@ shared_examples_for 'Tokenがおかしい時' do |exist: false, different: false
 end
 shared_examples_for ':idがおかしい時' do |exist: false, different: false|
   if exist
-    it '存在しない RecordNotFound' do
+    it '存在しない 404 Not Found' do
       set_not_exist_id
       expect(subject).to eq 404
     end
   end
   if different
-    it '異なる 401 Unauthorized' do
+    it '異なる 403 Forbidden' do
       set_different_id
       expect(subject).to eq 403
     end

--- a/spec/application_helper.rb
+++ b/spec/application_helper.rb
@@ -8,7 +8,7 @@ shared_examples_for 'Tokenがおかしい時' do |exist: false, different: false
   if different
     it '異なる 401 Unauthorized' do
       set_different_token
-      expect(subject).to eq 401
+      expect(subject).to eq 403
     end
   end
 end
@@ -16,13 +16,13 @@ shared_examples_for ':idがおかしい時' do |exist: false, different: false|
   if exist
     it '存在しない RecordNotFound' do
       set_not_exist_id
-      expect{ subject }.to raise_error ActiveRecord::RecordNotFound
+      expect(subject).to eq 404
     end
   end
   if different
     it '異なる 401 Unauthorized' do
       set_different_id
-      expect(subject).to eq 401
+      expect(subject).to eq 403
     end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe 'Users', type: :request do
         end
         describe 'DELETE' do
           subject { delete "/v1/users/#{@user_id}", headers: @options }
-          it { is_expected.to eq 200 }
+          it { is_expected.to eq 204 }
           it { expect { subject }.to change(User, :count).by(-1) }
           it_behaves_like 'Tokenがおかしい時', exist: true, different: true
           it_behaves_like ':idがおかしい時', exist: true, different: true


### PR DESCRIPTION
### やりたいこと
適切なステータスコードを返したい(成功、失敗含め)

### やったこと
- 例外時のエラーハンドリング
- DELETEの時は204
- 404, 500, 503はHTTPで返る→JSON形式にする
- 認可(権限)は403
- 認証失敗は401
- 404は何が存在しなかったか詳細を返す