### PR TITLE
Planのメソッドを責務毎に分離した

### DIFF
--- a/app/controllers/v1/date_suggests_controller.rb
+++ b/app/controllers/v1/date_suggests_controller.rb
@@ -3,7 +3,7 @@ module V1
     before_action :authorize!
 
     def suggest
-      render json: Plan.suggest(suggest_params)
+      render json: Plan.suggest!(suggest_params)
     end
 
     private

--- a/app/controllers/v1/date_suggests_controller.rb
+++ b/app/controllers/v1/date_suggests_controller.rb
@@ -3,7 +3,7 @@ module V1
     before_action :authorize!
 
     def suggest
-      render json: Plan.suggest!(suggest_params)
+      render json: PlanSuggest.suggest!(suggest_params)
     end
 
     private

--- a/app/controllers/v1/date_suggests_controller.rb
+++ b/app/controllers/v1/date_suggests_controller.rb
@@ -9,12 +9,10 @@ module V1
     private
 
       def suggest_params
-        suggest_params = SuggestParam.new(request.query_parameters)
-        suggest_params.attributes = {
-          user_area: @current_user.area_id,
-          birth_year: @current_user.birth_year
-        }
-        suggest_params if suggest_params.valid?
+        suggest_params = request.query_parameters
+        suggest_params[:user_area] = @current_user.area_id
+        suggest_params[:birth_year] = @current_user.birth_year
+        suggest_params
       end
   end
 end

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -15,6 +15,8 @@
 #  index_areas_on_region  (region)
 #
 class Area < ApplicationRecord
+  REGION_MAX_ID = 6
+
   enum region: {
     unknown: 0, ueno_region: 1, ikebukuro_region: 2,
     shinjuku_region: 3, shibuya_region: 4,
@@ -25,4 +27,46 @@ class Area < ApplicationRecord
   validates :order, numericality: { only_integer: true }
 
   scope :with_active, -> { where('"order" > ?', 0) }
+  scope :get_region_id, ->(area_id) { find(area_id).region_before_type_cast }
+  scope :sort_region, ->(user_region) { where(region: user_region) }
+  scope :sort_other_regions, lambda { |user_region|
+    exclusion_region = [0, user_region]
+    if user_region + 1 > REGION_MAX_ID
+      exclusion_region.push(1, user_region - 1)
+    elsif user_region - 1 <= 0
+      exclusion_region.push(REGION_MAX_ID, user_region + 1)
+    else
+      exclusion_region.push(user_region + 1, user_region - 1)
+    end
+    where.not(region: exclusion_region)
+  }
+
+  class << self
+    def get_date_areas(user_region, date_area)
+      case date_area
+      when 0
+        sort_region(user_region)
+      when 1
+        sort_other_regions(user_region)
+      else
+        raise ActionController::ParameterMissing, 'date_area の値が異常です'
+      end
+    end
+
+    def increase_region_id(user_region, count_num)
+      if user_region + count_num <= REGION_MAX_ID
+        user_region + count_num
+      else
+        user_region + count_num - REGION_MAX_ID
+      end
+    end
+
+    def reduce_region_id(user_region, count_num)
+      if (user_region - count_num).positive?
+        user_region - count_num
+      else
+        user_region - count_num + REGION_MAX_ID
+      end
+    end
+  end
 end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -32,14 +32,20 @@ class Plan < ApplicationRecord
 
   class << self
     def suggest!(params)
-      budget_range = UserType.calculation_budget_range(params.birth_year, params.date_budget)
-      user_region = Area.get_region_id(params.user_area)
-      sort_plans = sort(budget_range, params.date_area, user_region)
-      sort_plans = re_sort(budget_range, params.date_area, user_region) if sort_plans.blank?
+      suggest_params = check_suggest_params(params)
+      budget_range = UserType.calculation_budget_range(suggest_params.birth_year, suggest_params.date_budget)
+      user_region = Area.get_region_id(suggest_params.user_area)
+      sort_plans = sort(budget_range, suggest_params.date_area, user_region)
+      sort_plans = re_sort(budget_range, suggest_params.date_area, user_region) if sort_plans.blank?
       sort_plans.sample.presence || raise(ActiveRecord::RecordNotFound, '検索結果が見つかりませんでした。')
     end
 
     private
+
+      def check_suggest_params(params)
+        suggest_params = SuggestParam.new(params)
+        suggest_params if suggest_params.valid?
+      end
 
       def sort(budget_range, date_area, user_region)
         areas = Area.get_date_areas(user_region, date_area)

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -29,46 +29,4 @@ class Plan < ApplicationRecord
   validates :description, length: { in: 2..60 }
   validates :thumb, format: URI.regexp(%w[http https])
   validates :total_budget, numericality: { only_integer: true }
-
-  class << self
-    def suggest!(params)
-      suggest_params = check_suggest_params(params)
-      budget_range = UserType.calculation_budget_range(suggest_params.birth_year, suggest_params.date_budget)
-      user_region = Area.get_region_id(suggest_params.user_area)
-      sort_plans = sort(budget_range, suggest_params.date_area, user_region)
-      sort_plans = re_sort(budget_range, suggest_params.date_area, user_region) if sort_plans.blank?
-      sort_plans.sample.presence || raise(ActiveRecord::RecordNotFound, '検索結果が見つかりませんでした。')
-    end
-
-    private
-
-      def check_suggest_params(params)
-        suggest_params = SuggestParam.new(params)
-        suggest_params if suggest_params.valid?
-      end
-
-      def sort(budget_range, date_area, user_region)
-        areas = Area.get_date_areas(user_region, date_area)
-        Plan.where(total_budget: budget_range[0]...budget_range[1])
-            .where(area: areas)
-      end
-
-      def re_sort(budget_range, date_area, user_region)
-        count_num = 0
-        sort_plans = []
-        while sort_plans.blank?
-          break [] if count_num >= Area::REGION_MAX_ID
-
-          count_num += 1
-          user_region = Area.increase_region_id(user_region, count_num)
-          sort_plans = sort(budget_range, date_area, user_region)
-          return sort_plans if sort_plans.present?
-
-          count_num += 1
-          user_region = Area.reduce_region_id(user_region, count_num)
-          sort_plans = sort(budget_range, date_area, user_region)
-          return sort_plans if sort_plans.present?
-        end
-      end
-  end
 end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -21,9 +21,8 @@
 #  fk_rails_...  (area_id => areas.id)
 #
 class Plan < ApplicationRecord
-  REGION_MAX_ID = 6
-
   has_many :plan_spots, dependent: :destroy
+  has_many :my_plans, dependent: :destroy
   belongs_to :area
 
   validates :title, length: { in: 2..20 }
@@ -32,110 +31,37 @@ class Plan < ApplicationRecord
   validates :total_budget, numericality: { only_integer: true }
 
   class << self
-    def suggest(params)
-      sorted_plans = sort_plans(params)
-      raise ActiveRecord::RecordNotFound, '検索結果が見つかりませんでした。' if sorted_plans.blank?
-
-      sorted_plans.sample
+    def suggest!(params)
+      budget_range = UserType.calculation_budget_range(params.birth_year, params.date_budget)
+      user_region = Area.get_region_id(params.user_area)
+      sort_plans = sort(budget_range, params.date_area, user_region)
+      sort_plans = re_sort(budget_range, params.date_area, user_region) if sort_plans.blank?
+      sort_plans.sample.presence || raise(ActiveRecord::RecordNotFound, '検索結果が見つかりませんでした。')
     end
 
     private
 
-      def sort_plans(params)
-        budget_range = calculation_budget_range(params.birth_year, params.date_budget)
-        date_area = params.date_area
-        user_region = Area.find(params.user_area).region_before_type_cast
-        sort_plans = sorted(budget_range, date_area, user_region)
-        sort_plans = re_sort(budget_range, date_area, user_region) if sort_plans.blank?
-        sort_plans
-      end
-
-      def sorted(budget_range, date_area, user_region)
-        areas = get_areas(user_region, date_area)
+      def sort(budget_range, date_area, user_region)
+        areas = Area.get_date_areas(user_region, date_area)
         Plan.where(total_budget: budget_range[0]...budget_range[1])
             .where(area: areas)
       end
 
       def re_sort(budget_range, date_area, user_region)
-        count_num = 1
+        count_num = 0
         sort_plans = []
         while sort_plans.blank?
-          break [] if count_num >= REGION_MAX_ID
+          break [] if count_num >= Area::REGION_MAX_ID
 
-          user_region = increase_region_id(user_region, count_num)
-          sort_plans = sorted(budget_range, date_area, user_region)
+          count_num += 1
+          user_region = Area.increase_region_id(user_region, count_num)
+          sort_plans = sort(budget_range, date_area, user_region)
           return sort_plans if sort_plans.present?
 
-          user_region = reduce_region_id(user_region, count_num)
-          sort_plans = sorted(budget_range, date_area, user_region)
+          count_num += 1
+          user_region = Area.reduce_region_id(user_region, count_num)
+          sort_plans = sort(budget_range, date_area, user_region)
           return sort_plans if sort_plans.present?
-
-          count_num += 2
-        end
-      end
-
-      def increase_region_id(user_region, count_num)
-        if user_region + count_num <= REGION_MAX_ID
-          user_region + count_num
-        else
-          user_region + count_num - REGION_MAX_ID
-        end
-      end
-
-      def reduce_region_id(user_region, count_num)
-        if (user_region - (count_num + 1)).positive?
-          user_region - (count_num + 1)
-        else
-          user_region - (count_num + 1) + REGION_MAX_ID
-        end
-      end
-
-      def calculation_budget_range(birth_year, date_budget)
-        standard_budget = get_standard_budget(birth_year)
-        to_budget_range(standard_budget, date_budget)
-      end
-
-      def get_standard_budget(birth_year)
-        tens_place_age, early_or_late = trans_age(birth_year)
-        UserType.get_budget(tens_place_age, early_or_late)
-      end
-
-      def trans_age(birth_year)
-        age = Time.current.year - birth_year
-        tens_place_age = age / 10
-        early_or_late = age % 10 < 5 ? 0 : 1
-        [tens_place_age, early_or_late]
-      end
-
-      def to_budget_range(standard_budget, date_budget)
-        case date_budget
-        when 0
-          [(standard_budget * 0).round, (standard_budget * 0.7).round]
-        when 1
-          [(standard_budget * 0.7).round, (standard_budget * 1.6).round]
-        when 2
-          [(standard_budget * 1.6).round, (standard_budget * 3).round]
-        else
-          raise ActionController::ParameterMissing, 'date_budget の値が異常です'
-        end
-      end
-
-      def get_areas(user_region, date_area)
-        case date_area
-        when 0
-          Area.where(region: user_region)
-        when 1
-          exclusion_region = [0, user_region]
-          if user_region + 1 > REGION_MAX_ID
-            exclusion_region.push(1, user_region - 1)
-          elsif user_region - 1 <= 0
-            exclusion_region.push(REGION_MAX_ID, user_region + 1)
-          else
-            exclusion_region.push(user_region + 1, user_region - 1)
-          end
-          Area.where.not(region: exclusion_region)
-        else
-          raise ActionController::ParameterMissing, 'date_area の値が異常です'
         end
       end
   end

--- a/app/models/plan_suggest.rb
+++ b/app/models/plan_suggest.rb
@@ -12,7 +12,7 @@ class PlanSuggest
     private
 
       def check_suggest_params(params)
-        suggest_params = SuggestParam.new(params)
+        suggest_params = PlanSuggestParam.new(params)
         suggest_params if suggest_params.valid?
       end
 

--- a/app/models/plan_suggest.rb
+++ b/app/models/plan_suggest.rb
@@ -1,0 +1,43 @@
+class PlanSuggest
+  class << self
+    def suggest!(params)
+      suggest_params = check_suggest_params(params)
+      budget_range = UserType.calculation_budget_range(suggest_params.birth_year, suggest_params.date_budget)
+      user_region = Area.get_region_id(suggest_params.user_area)
+      sort_plans = sort(budget_range, suggest_params.date_area, user_region)
+      sort_plans = re_sort(budget_range, suggest_params.date_area, user_region) if sort_plans.blank?
+      sort_plans.sample.presence || raise(ActiveRecord::RecordNotFound, '検索結果が見つかりませんでした。')
+    end
+
+    private
+
+      def check_suggest_params(params)
+        suggest_params = SuggestParam.new(params)
+        suggest_params if suggest_params.valid?
+      end
+
+      def sort(budget_range, date_area, user_region)
+        areas = Area.get_date_areas(user_region, date_area)
+        Plan.where(total_budget: budget_range[0]...budget_range[1])
+            .where(area: areas)
+      end
+
+      def re_sort(budget_range, date_area, user_region)
+        count_num = 0
+        sort_plans = []
+        while sort_plans.blank?
+          break [] if count_num >= Area::REGION_MAX_ID
+
+          count_num += 1
+          user_region = Area.increase_region_id(user_region, count_num)
+          sort_plans = sort(budget_range, date_area, user_region)
+          return sort_plans if sort_plans.present?
+
+          count_num += 1
+          user_region = Area.reduce_region_id(user_region, count_num)
+          sort_plans = sort(budget_range, date_area, user_region)
+          return sort_plans if sort_plans.present?
+        end
+      end
+  end
+end

--- a/app/models/plan_suggest_param.rb
+++ b/app/models/plan_suggest_param.rb
@@ -1,4 +1,4 @@
-class SuggestParam
+class PlanSuggestParam
   include ActiveModel::Model
   include ActiveModel::Attributes
 

--- a/app/models/user_type.rb
+++ b/app/models/user_type.rb
@@ -23,9 +23,43 @@ class UserType < ApplicationRecord
   validates :early_or_late, numericality: { in: 0..1 }
   validates :standard_budget, numericality: { in: 0..50000 }
 
-  scope :get_budget, lambda { |tens_place_age, early_or_late|
+  scope :get_standard_budget_from_user_types, lambda { |tens_place_age, early_or_late|
     where(tens_place_age: tens_place_age)
       .find_by(early_or_late: early_or_late)
       .standard_budget
   }
+
+  class << self
+    def calculation_budget_range(birth_year, date_budget)
+      standard_budget = get_standard_budget(birth_year)
+      to_budget_range(standard_budget, date_budget)
+    end
+
+    private
+
+      def get_standard_budget(birth_year)
+        tens_place_age, early_or_late = trans_age(birth_year)
+        get_standard_budget_from_user_types(tens_place_age, early_or_late)
+      end
+
+      def trans_age(birth_year)
+        age = Time.current.year - birth_year
+        tens_place_age = age / 10
+        early_or_late = age % 10 < 5 ? 0 : 1
+        [tens_place_age, early_or_late]
+      end
+
+      def to_budget_range(standard_budget, date_budget)
+        case date_budget
+        when 0
+          [(standard_budget * 0).round, (standard_budget * 0.7).round]
+        when 1
+          [(standard_budget * 0.7).round, (standard_budget * 1.6).round]
+        when 2
+          [(standard_budget * 1.6).round, (standard_budget * 3).round]
+        else
+          raise ActionController::ParameterMissing, 'date_budget の値が異常です'
+        end
+      end
+  end
 end


### PR DESCRIPTION
### やりたいこと
Planのメソッドを関心事にそれぞれ分離する

### やったこと
* Plan ModelのメソッドをUserType, AreaのModelに分離した
* メソッド名を理解しやすい命名に変更した
* パラメータチェックをModelに移行した
* suggestのメソッドをPlan -> PlanSuggest に移行した
* Rename SuggestParam -> PlanSuggestParam